### PR TITLE
fix(db): add image_url to content_posts and create llm_usage_events table

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -228,8 +228,21 @@ function migrate(db: Database.Database) {
       last_synced_at INTEGER
     );
 
+    CREATE TABLE IF NOT EXISTS llm_usage_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      day TEXT NOT NULL,
+      agent_id TEXT,
+      model TEXT,
+      total_tokens INTEGER DEFAULT 0,
+      cost_usd REAL DEFAULT 0,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE INDEX IF NOT EXISTS idx_llm_usage_day ON llm_usage_events(day);
+    CREATE INDEX IF NOT EXISTS idx_llm_usage_agent ON llm_usage_events(agent_id, day);
+
   `);
 
   // Column migrations (safe to re-run)
   try { db.exec("ALTER TABLE leads ADD COLUMN pause_outreach INTEGER DEFAULT 0"); } catch { /* column exists */ }
+  try { db.exec("ALTER TABLE content_posts ADD COLUMN image_url TEXT"); } catch { /* column exists */ }
 }


### PR DESCRIPTION
## Problem\n\nOn a fresh deploy (empty SQLite state), two API endpoints return HTTP 500:\n\n- `GET /api/approvals` → `SqliteError: no such column: image_url`\n- `GET /api/usage` → 500 (queries `llm_usage_events` which is never created)\n\n## Fix\n\n- Add `image_url TEXT` column to `content_posts` via a safe `ALTER TABLE … ADD COLUMN` migration (matches the column the approvals route selects).\n- Create the `llm_usage_events` table (`day`, `agent_id`, `model`, `total_tokens`, `cost_usd`, `created_at`) with indexes on `day` and `agent_id`, matching the usage route queries.\n\n## Validation\n\nDeployed to production and re-ran the full e2e sweep: `/api/approvals` and `/api/usage` now return 200; **85/85 tests passed**.\n\nCloses #9