### PR TITLE
Pin GitHub Actions to commit SHAs and add permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,15 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Template Audit
         run: |
@@ -20,12 +23,12 @@ jobs:
           bash ./scripts/template-audit.sh
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

This PR improves workflow security by pinning all GitHub Actions to specific commit SHAs and adding explicit permissions.

### Actions Pinned

- **actions/checkout**: `11d5960a326750d5838078e36cf38b85af677262` (v4)
- **pnpm/action-setup**: `b906affcce14559ad1aafd4ab0e942779e9f58b1` (v4)
- **actions/setup-node**: `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4)

### Permissions Added

Added top-level `permissions: contents: read` to follow the principle of least privilege.

### Why These Changes?

1. **Commit SHA Pinning**: Protects against malicious tag updates or compromised action repositories
2. **Explicit Permissions**: Reduces the default token permissions from write to read-only, limiting potential security impact

### Verification

All commit SHAs were resolved from official GitHub repositories:
- https://github.com/actions/checkout
- https://github.com/pnpm/action-setup
- https://github.com/actions/setup-node

No application code, dependencies, or lockfiles were modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba4a744c-9af4-4c90-a037-184f4f0e972e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba4a744c-9af4-4c90-a037-184f4f0e972e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

